### PR TITLE
Add cleanup for debounced filter change in advanced search

### DIFF
--- a/components/advanced-search.tsx
+++ b/components/advanced-search.tsx
@@ -71,6 +71,7 @@ export function AdvancedSearch({ onFiltersChange, totalResults, isLoading = fals
 
   useEffect(() => {
     debouncedFilterChange(filters)
+    return () => debouncedFilterChange.cancel()
   }, [filters, debouncedFilterChange])
 
   const fetchTags = async () => {


### PR DESCRIPTION
## Summary
- cancel pending debounced filter updates when advanced search unmounts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_689ef7a73de08332b5260a7dcc54b075