### PR TITLE
refactor: use shared Prisma instance in API routes

### DIFF
--- a/app/api/cards/[id]/route.ts
+++ b/app/api/cards/[id]/route.ts
@@ -1,8 +1,6 @@
 
 import { NextRequest, NextResponse } from 'next/server'
-import { PrismaClient } from '@prisma/client'
-
-const prisma = new PrismaClient()
+import { prisma } from '@/lib/db'
 
 export const dynamic = 'force-dynamic'
 

--- a/app/api/cards/route.ts
+++ b/app/api/cards/route.ts
@@ -1,8 +1,6 @@
 
 import { NextRequest, NextResponse } from 'next/server'
-import { PrismaClient } from '@prisma/client'
-
-const prisma = new PrismaClient()
+import { prisma } from '@/lib/db'
 
 export const dynamic = 'force-dynamic'
 

--- a/app/api/cards/search/route.ts
+++ b/app/api/cards/search/route.ts
@@ -1,8 +1,6 @@
 
 import { NextRequest, NextResponse } from 'next/server'
-import { PrismaClient } from '@prisma/client'
-
-const prisma = new PrismaClient()
+import { prisma } from '@/lib/db'
 
 export const dynamic = 'force-dynamic'
 

--- a/app/api/tags/route.ts
+++ b/app/api/tags/route.ts
@@ -1,8 +1,6 @@
 
 import { NextRequest, NextResponse } from 'next/server'
-import { PrismaClient } from '@prisma/client'
-
-const prisma = new PrismaClient()
+import { prisma } from '@/lib/db'
 
 export const dynamic = 'force-dynamic'
 


### PR DESCRIPTION
## Summary
- use shared Prisma client in card and tag API routes

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm run type-check` *(fails: existing type errors)*

------
https://chatgpt.com/codex/tasks/task_e_689ef77d0f6c83329b9fe4ff6654ae74