### PR TITLE
feat: add user auth and token middleware

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import bcrypt from 'bcryptjs'
+import { signToken, AUTH_COOKIE } from '@/lib/auth'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(req: NextRequest) {
+  try {
+    const { email, password } = await req.json()
+    if (!email || !password) {
+      return NextResponse.json({ error: 'Email y contraseña requeridos' }, { status: 400 })
+    }
+
+    const user = await prisma.user.findUnique({ where: { email } })
+    if (!user) {
+      return NextResponse.json({ error: 'Credenciales inválidas' }, { status: 401 })
+    }
+
+    const valid = await bcrypt.compare(password, user.password)
+    if (!valid) {
+      return NextResponse.json({ error: 'Credenciales inválidas' }, { status: 401 })
+    }
+
+    const token = signToken(user.id)
+    const res = NextResponse.json({ id: user.id, name: user.name, email: user.email })
+    res.cookies.set(AUTH_COOKIE, token, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      path: '/',
+    })
+    return res
+  } catch (error) {
+    console.error('Error en login:', error)
+    return NextResponse.json({ error: 'Error interno del servidor' }, { status: 500 })
+  }
+}

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import bcrypt from 'bcryptjs'
+import { signToken, AUTH_COOKIE } from '@/lib/auth'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(req: NextRequest) {
+  try {
+    const { name, email, password } = await req.json()
+    if (!email || !password) {
+      return NextResponse.json({ error: 'Email y contraseña requeridos' }, { status: 400 })
+    }
+
+    const existing = await prisma.user.findUnique({ where: { email } })
+    if (existing) {
+      return NextResponse.json({ error: 'El usuario ya existe' }, { status: 400 })
+    }
+
+    const hashedPassword = await bcrypt.hash(password, 10)
+    const user = await prisma.user.create({
+      data: { name, email, password: hashedPassword }
+    })
+
+    const token = signToken(user.id)
+    const res = NextResponse.json({ id: user.id, name: user.name, email: user.email })
+    res.cookies.set(AUTH_COOKIE, token, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      path: '/',
+    })
+    return res
+  } catch (error) {
+    console.error('Error en registro:', error)
+    return NextResponse.json({ error: 'Error interno del servidor' }, { status: 500 })
+  }
+}

--- a/app/api/cards/route.ts
+++ b/app/api/cards/route.ts
@@ -1,12 +1,18 @@
 
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { getUserIdFromRequest } from '@/lib/auth'
 
 export const dynamic = 'force-dynamic'
 
 // GET - Obtener todas las fichas con filtros
 export async function GET(request: NextRequest) {
   try {
+    const userId = getUserIdFromRequest(request)
+    if (!userId) {
+      return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
+    }
+
     const { searchParams } = new URL(request.url)
     const search = searchParams.get('search')
     const tag = searchParams.get('tag')
@@ -14,7 +20,7 @@ export async function GET(request: NextRequest) {
     const limit = parseInt(searchParams.get('limit') || '20')
     const skip = (page - 1) * limit
 
-    let where: any = {}
+    let where: any = { userId }
 
     // Búsqueda de texto completo
     if (search) {
@@ -83,6 +89,11 @@ export async function GET(request: NextRequest) {
 // POST - Crear nueva ficha
 export async function POST(request: NextRequest) {
   try {
+    const userId = getUserIdFromRequest(request)
+    if (!userId) {
+      return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
+    }
+
     const data = await request.json()
     const { title, source, level1, level2, level3, level4, questions, tags } = data
 
@@ -102,6 +113,7 @@ export async function POST(request: NextRequest) {
         level3,
         level4,
         questions: questions || [],
+        userId,
         tags: {
           create: tags?.map((tagName: string) => ({
             tag: {

--- a/app/api/cards/search/route.ts
+++ b/app/api/cards/search/route.ts
@@ -1,11 +1,17 @@
 
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { getUserIdFromRequest } from '@/lib/auth'
 
 export const dynamic = 'force-dynamic'
 
 export async function GET(request: NextRequest) {
   try {
+    const userId = getUserIdFromRequest(request)
+    if (!userId) {
+      return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
+    }
+
     const { searchParams } = new URL(request.url)
     const search = searchParams.get('search')
     const tags = searchParams.getAll('tags')
@@ -16,7 +22,7 @@ export async function GET(request: NextRequest) {
     const dateRange = searchParams.get('dateRange') || 'all'
     const skip = (page - 1) * limit
 
-    let where: any = {}
+    let where: any = { userId }
 
     // Búsqueda de texto completo
     if (search) {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,24 @@
+import jwt from 'jsonwebtoken'
+import { NextRequest } from 'next/server'
+
+const JWT_SECRET = process.env.JWT_SECRET || 'secret'
+export const AUTH_COOKIE = 'token'
+
+export function signToken(userId: string) {
+  return jwt.sign({ userId }, JWT_SECRET, { expiresIn: '7d' })
+}
+
+export function verifyToken(token: string): { userId: string } {
+  return jwt.verify(token, JWT_SECRET) as { userId: string }
+}
+
+export function getUserIdFromRequest(req: NextRequest): string | null {
+  const token = req.cookies.get(AUTH_COOKIE)?.value
+  if (!token) return null
+  try {
+    const { userId } = verifyToken(token)
+    return userId
+  } catch {
+    return null
+  }
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyToken, AUTH_COOKIE } from './lib/auth'
+
+export function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl
+  if (pathname.startsWith('/api/auth')) {
+    return NextResponse.next()
+  }
+
+  const token = req.cookies.get(AUTH_COOKIE)?.value
+  if (!token) {
+    return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
+  }
+
+  try {
+    verifyToken(token)
+    return NextResponse.next()
+  } catch {
+    return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
+  }
+}
+
+export const config = {
+  matcher: '/api/:path*'
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,6 +7,19 @@ datasource db {
     url    = env("DATABASE_URL")
 }
 
+model User {
+  id        String   @id @default(cuid())
+  name      String?
+  email     String   @unique
+  password  String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  cards     Card[]
+
+  @@map("users")
+}
+
 model Card {
   id    String   @id @default(cuid())
   title    String
@@ -20,10 +33,13 @@ model Card {
   
   // Preguntas de autoevaluación
   questions   String[] // Array de preguntas generadas
-  
+
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
-  
+
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
   // Relación con etiquetas (muchos a muchos)
   tags    CardTag[]
   

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,10 +1,22 @@
 
 import { PrismaClient } from '@prisma/client'
+import bcrypt from 'bcryptjs'
 
 const prisma = new PrismaClient()
 
 async function main() {
   console.log('🌱 Iniciando seed de la base de datos...')
+
+  // Crear usuario demo
+  const demoUser = await prisma.user.upsert({
+    where: { email: 'demo@example.com' },
+    update: {},
+    create: {
+      email: 'demo@example.com',
+      name: 'Demo',
+      password: await bcrypt.hash('password', 10)
+    }
+  })
 
   // Crear etiquetas
   const tags = await Promise.all([
@@ -92,6 +104,7 @@ async function main() {
         level3: cardData.level3,
         level4: cardData.level4,
         questions: cardData.questions,
+        userId: demoUser.id,
         tags: {
           create: tagNames.map(tagName => ({
             tag: {


### PR DESCRIPTION
## Summary
- add User model and userId relation for cards
- implement JWT auth helpers and API routes for register and login
- secure API routes with middleware validating auth cookie

## Testing
- `npx prisma migrate dev --name add-user-model` *(fails: P1001 Can't reach database server at `localhost:5432`)*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: asks for ESLint configuration)*
- `npm run type-check` *(fails: TS errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689efa654b0483328b06bfac5584a2de