### PR TITLE
Add auth hook and user menu

### DIFF
--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -7,6 +7,15 @@ import { usePathname } from 'next/navigation'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Badge } from '@/components/ui/badge'
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from '@/components/ui/dropdown-menu'
+import { Avatar, AvatarFallback } from '@/components/ui/avatar'
+import { useAuth } from '@/hooks/useAuth'
 import { 
   Brain, 
   Search, 
@@ -37,6 +46,7 @@ export function Navigation({ onSearch, onTagFilter, searchQuery = '', selectedTa
   const pathname = usePathname()
   const [tags, setTags] = useState<Tag[]>([])
   const [localSearch, setLocalSearch] = useState(searchQuery)
+  const { user, logout } = useAuth()
 
   useEffect(() => {
     fetchTags()
@@ -118,26 +128,28 @@ export function Navigation({ onSearch, onTagFilter, searchQuery = '', selectedTa
           </nav>
 
           {/* Search */}
-          {(pathname === '/' || pathname?.startsWith('/cards')) && (
-            <div className="flex-1 max-w-md mx-4">
-              <div className="relative">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 h-4 w-4" />
-                <Input
-                  type="search"
-                  placeholder="Buscar fichas..."
-                  value={localSearch}
-                  onChange={(e) => handleSearchChange(e.target.value)}
-                  className="pl-10 bg-slate-50 dark:bg-slate-800 border-slate-200 dark:border-slate-700"
-                />
-              </div>
+        {(pathname === '/' || pathname?.startsWith('/cards')) && (
+          <div className="flex-1 max-w-md mx-4">
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 h-4 w-4" />
+              <Input
+                type="search"
+                placeholder="Buscar fichas..."
+                value={localSearch}
+                onChange={(e) => handleSearchChange(e.target.value)}
+                className="pl-10 bg-slate-50 dark:bg-slate-800 border-slate-200 dark:border-slate-700"
+              />
             </div>
-          )}
+          </div>
+        )}
 
-          {/* Mobile menu button */}
-          <Button
-            variant="ghost"
-            size="sm"
-            className="md:hidden"
+        {user && <UserMenu user={user} onLogout={logout} />}
+
+        {/* Mobile menu button */}
+        <Button
+          variant="ghost"
+          size="sm"
+          className="md:hidden"
           >
             <Settings className="h-5 w-5" />
           </Button>
@@ -179,5 +191,34 @@ export function Navigation({ onSearch, onTagFilter, searchQuery = '', selectedTa
         )}
       </div>
     </header>
+  )
+}
+
+interface UserMenuProps {
+  user: { name?: string; email?: string }
+  onLogout: () => void
+}
+
+function UserMenu({ user, onLogout }: UserMenuProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" className="relative h-8 w-8 rounded-full">
+          <Avatar className="h-8 w-8">
+            <AvatarFallback>
+              {user.name?.charAt(0).toUpperCase()}
+            </AvatarFallback>
+          </Avatar>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        <div className="flex flex-col gap-1 p-2">
+          <p className="text-sm font-medium leading-none">{user.name}</p>
+          <p className="text-xs text-muted-foreground">{user.email}</p>
+        </div>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={onLogout}>Cerrar sesión</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -1,0 +1,65 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { parse } from 'cookie'
+import { AUTH_COOKIE } from '@/lib/auth'
+
+interface User {
+  id: string
+  name: string
+  email: string
+}
+
+function getToken(): string | null {
+  if (typeof document === 'undefined') return null
+  const fromStorage =
+    localStorage.getItem('Authorization') || localStorage.getItem('token')
+  if (fromStorage) return fromStorage
+  const cookies = parse(document.cookie ?? '')
+  return cookies[AUTH_COOKIE] ?? null
+}
+
+export function useAuth() {
+  const [user, setUser] = useState<User | null>(null)
+
+  useEffect(() => {
+    const token = getToken()
+    if (!token) return
+    const stored = localStorage.getItem('user')
+    if (stored) {
+      try {
+        setUser(JSON.parse(stored) as User)
+      } catch {
+        // ignore parse errors
+      }
+    }
+  }, [])
+
+  const login = useCallback(async (email: string, password: string) => {
+    const res = await fetch('/api/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    })
+    if (!res.ok) {
+      throw new Error('Login failed')
+    }
+    const data = (await res.json()) as User
+    setUser(data)
+    localStorage.setItem('user', JSON.stringify(data))
+    return data
+  }, [])
+
+  const logout = useCallback(() => {
+    if (typeof document !== 'undefined') {
+      document.cookie = `${AUTH_COOKIE}=; Max-Age=0; path=/`
+    }
+    localStorage.removeItem('user')
+    localStorage.removeItem('Authorization')
+    localStorage.removeItem('token')
+    setUser(null)
+  }, [])
+
+  return { user, login, logout }
+}
+


### PR DESCRIPTION
## Summary
- implement `useAuth` hook that manages token, login and logout
- show authenticated user info with logout option in navigation

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run type-check` *(fails: existing type errors in repo)*

------
https://chatgpt.com/codex/tasks/task_e_689efd3e90608332b39b9a56e4313753