### PR TITLE
Require authentication for card APIs and handle unauth states

### DIFF
--- a/app/api/cards/[id]/route.ts
+++ b/app/api/cards/[id]/route.ts
@@ -10,12 +10,12 @@ export async function GET(
   request: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  try {
-    const userId = getUserIdFromRequest(request)
-    if (!userId) {
-      return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    }
+  const userId = getUserIdFromRequest(request)
+  if (!userId) {
+    return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
+  }
 
+  try {
     const card = await prisma.card.findFirst({
       where: { id: params.id, userId },
       include: {
@@ -55,12 +55,12 @@ export async function PUT(
   request: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  try {
-    const userId = getUserIdFromRequest(request)
-    if (!userId) {
-      return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    }
+  const userId = getUserIdFromRequest(request)
+  if (!userId) {
+    return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
+  }
 
+  try {
     const data = await request.json()
     const { title, source, level1, level2, level3, level4, questions, tags } = data
 
@@ -125,12 +125,12 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  try {
-    const userId = getUserIdFromRequest(request)
-    if (!userId) {
-      return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    }
+  const userId = getUserIdFromRequest(request)
+  if (!userId) {
+    return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
+  }
 
+  try {
     const card = await prisma.card.findFirst({ where: { id: params.id, userId } })
     if (!card) {
       return NextResponse.json({ error: 'Ficha no encontrada' }, { status: 404 })

--- a/app/api/cards/route.ts
+++ b/app/api/cards/route.ts
@@ -2,17 +2,18 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { getUserIdFromRequest } from '@/lib/auth'
+import { Prisma } from '@prisma/client'
 
 export const dynamic = 'force-dynamic'
 
 // GET - Obtener todas las fichas con filtros
 export async function GET(request: NextRequest) {
-  try {
-    const userId = getUserIdFromRequest(request)
-    if (!userId) {
-      return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    }
+  const userId = getUserIdFromRequest(request)
+  if (!userId) {
+    return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
+  }
 
+  try {
     const { searchParams } = new URL(request.url)
     const search = searchParams.get('search')
     const tag = searchParams.get('tag')
@@ -20,7 +21,7 @@ export async function GET(request: NextRequest) {
     const limit = parseInt(searchParams.get('limit') || '20')
     const skip = (page - 1) * limit
 
-    let where: any = { userId }
+    let where: Prisma.CardWhereInput = { userId }
 
     // Búsqueda de texto completo
     if (search) {
@@ -88,12 +89,12 @@ export async function GET(request: NextRequest) {
 
 // POST - Crear nueva ficha
 export async function POST(request: NextRequest) {
-  try {
-    const userId = getUserIdFromRequest(request)
-    if (!userId) {
-      return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
-    }
+  const userId = getUserIdFromRequest(request)
+  if (!userId) {
+    return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
+  }
 
+  try {
     const data = await request.json()
     const { title, source, level1, level2, level3, level4, questions, tags } = data
 

--- a/components/card-view-page.tsx
+++ b/components/card-view-page.tsx
@@ -39,8 +39,15 @@ export function CardViewPage({ cardId }: CardViewPageProps) {
   const fetchCard = async () => {
     try {
       setLoading(true)
-      const response = await fetch(`/api/cards/${cardId}`)
-      
+      setError('')
+      const response = await fetch(`/api/cards/${cardId}`, {
+        credentials: 'include'
+      })
+
+      if (response.status === 401) {
+        setError('Debes iniciar sesión para ver esta ficha')
+        return
+      }
       if (!response.ok) {
         if (response.status === 404) {
           setError('Ficha no encontrada')
@@ -72,6 +79,7 @@ export function CardViewPage({ cardId }: CardViewPageProps) {
   }
 
   if (error || !card) {
+    const unauthorized = error.includes('iniciar sesión')
     return (
       <div className="min-h-screen">
         <Navigation />
@@ -88,14 +96,22 @@ export function CardViewPage({ cardId }: CardViewPageProps) {
               {error || 'Ficha no encontrada'}
             </h2>
             <p className="text-slate-600 dark:text-slate-400 mb-6">
-              No se pudo cargar la ficha solicitada. Es posible que haya sido eliminada.
+              {unauthorized
+                ? 'Debes iniciar sesión para acceder a esta ficha.'
+                : 'No se pudo cargar la ficha solicitada. Es posible que haya sido eliminada.'}
             </p>
-            <Link href="/">
-              <Button>
-                <ArrowLeft className="h-4 w-4 mr-2" />
-                Volver al Inicio
-              </Button>
-            </Link>
+            {unauthorized ? (
+              <Link href="/login">
+                <Button>Iniciar sesión</Button>
+              </Link>
+            ) : (
+              <Link href="/">
+                <Button>
+                  <ArrowLeft className="h-4 w-4 mr-2" />
+                  Volver al Inicio
+                </Button>
+              </Link>
+            )}
           </motion.div>
         </main>
       </div>

--- a/components/enhanced-home-page.tsx
+++ b/components/enhanced-home-page.tsx
@@ -53,6 +53,7 @@ export function EnhancedHomePage() {
     total: 0,
     totalPages: 0
   })
+  const [error, setError] = useState('')
   const [filters, setFilters] = useState<SearchFilters>({
     query: '',
     tags: [],
@@ -68,6 +69,7 @@ export function EnhancedHomePage() {
   const fetchCards = async (page = 1) => {
     try {
       setLoading(true)
+      setError('')
       const params = new URLSearchParams({
         page: page.toString(),
         limit: '12',
@@ -81,7 +83,15 @@ export function EnhancedHomePage() {
       }
       if (filters.dateRange !== 'all') params.set('dateRange', filters.dateRange)
 
-      const response = await fetch(`/api/cards/search?${params}`)
+      const response = await fetch(`/api/cards/search?${params}`, {
+        credentials: 'include'
+      })
+      if (response.status === 401) {
+        setError('Debes iniciar sesión para ver tus fichas')
+        setCards([])
+        setPagination({ page: 1, total: 0, totalPages: 0 })
+        return
+      }
       if (response.ok) {
         const data: PaginatedResponse = await response.json()
         setCards(data.cards)
@@ -134,6 +144,22 @@ export function EnhancedHomePage() {
   ]
 
   const hasFilters = filters.query || filters.tags.length > 0 || filters.dateRange !== 'all'
+
+  if (error) {
+    return (
+      <div className="min-h-screen">
+        <Navigation />
+        <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          <div className="text-center py-12">
+            <p className="text-slate-600 dark:text-slate-400 mb-6">{error}</p>
+            <Link href="/login">
+              <Button>Iniciar sesión</Button>
+            </Link>
+          </div>
+        </main>
+      </div>
+    )
+  }
 
   return (
     <div className="min-h-screen">

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -12,8 +12,22 @@ export function verifyToken(token: string): { userId: string } {
   return jwt.verify(token, JWT_SECRET) as { userId: string }
 }
 
+/**
+ * Extracts the userId from either the auth cookie or the Authorization header.
+ * Returns null if no valid token is present.
+ */
 export function getUserIdFromRequest(req: NextRequest): string | null {
-  const token = req.cookies.get(AUTH_COOKIE)?.value
+  let token = req.cookies.get(AUTH_COOKIE)?.value
+
+  if (!token) {
+    const authHeader = req.headers.get('Authorization') || ''
+    if (authHeader.startsWith('Bearer ')) {
+      token = authHeader.slice(7)
+    } else if (authHeader) {
+      token = authHeader
+    }
+  }
+
   if (!token) return null
   try {
     const { userId } = verifyToken(token)


### PR DESCRIPTION
## Summary
- ensure card API routes validate auth token and scope queries by user id
- allow auth helper to read Authorization header in addition to cookie
- send credentials from card pages and show login prompt when unauthorized

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: interactive ESLint setup prompt)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_689eff84ddf88332bf84e04566a03a77