### PR TITLE
feat: configurable auth cookie secure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# Synapsis AI
+
+## Environment Variables
+
+- `AUTH_COOKIE_SECURE`: Forces the `secure` attribute on the authentication cookie. When not set, the server derives the value from the request protocol.
+  **HTTP deployments must set `AUTH_COOKIE_SECURE=false`** to allow cookies over plain HTTP.

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -23,10 +23,14 @@ export async function POST(req: NextRequest) {
     }
 
     const token = signToken(user.id)
+    const secure =
+      process.env.AUTH_COOKIE_SECURE !== undefined
+        ? process.env.AUTH_COOKIE_SECURE === 'true'
+        : req.nextUrl.protocol === 'https:'
     const res = NextResponse.json({ id: user.id, name: user.name, email: user.email })
     res.cookies.set(AUTH_COOKIE, token, {
       httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
+      secure,
       sameSite: 'lax',
       path: '/',
     })


### PR DESCRIPTION
## Summary
- allow deriving auth cookie security from request protocol or `AUTH_COOKIE_SECURE` env flag
- document `AUTH_COOKIE_SECURE` usage and HTTP deployment requirement in README

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive ESLint config)
- `npm run type-check` (fails: TS errors in components and API route)


------
https://chatgpt.com/codex/tasks/task_e_689f16e2931c83328404f45bab8a0d41