### PR TITLE
feat: add session validation

### DIFF
--- a/app/api/auth/me/route.ts
+++ b/app/api/auth/me/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { getUserIdFromRequest } from '@/lib/auth'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(req: NextRequest) {
+  try {
+    const userId = getUserIdFromRequest(req)
+    if (!userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, name: true, email: true },
+    })
+
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 })
+    }
+
+    return NextResponse.json(user)
+  } catch (error) {
+    console.error('Error fetching current user:', error)
+    return NextResponse.json(
+      { error: 'Error interno del servidor' },
+      { status: 500 }
+    )
+  }
+}

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -23,15 +23,27 @@ export function useAuth() {
   const [user, setUser] = useState<User | null>(null)
 
   useEffect(() => {
-    const token = getToken()
-    if (!token) return
     const stored = localStorage.getItem('user')
     if (stored) {
       try {
         setUser(JSON.parse(stored) as User)
+        return
       } catch {
         // ignore parse errors
       }
+    }
+
+    const token = getToken()
+    if (token) {
+      fetch('/api/auth/me', { credentials: 'include' })
+        .then((res) => (res.ok ? res.json() : null))
+        .then((data) => {
+          if (data) {
+            setUser(data as User)
+            localStorage.setItem('user', JSON.stringify(data))
+          }
+        })
+        .catch(() => {})
     }
   }, [])
 


### PR DESCRIPTION
## Summary
- load auth user from local storage or `/api/auth/me`
- add `/api/auth/me` route to validate sessions

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm run type-check` *(fails: components/theme-provider.tsx cannot find module, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689f16f4a1dc8332bf8e9965634af24d