### PR TITLE
Handle unauthenticated card fetches

### DIFF
--- a/components/study-page.tsx
+++ b/components/study-page.tsx
@@ -46,14 +46,26 @@ export function StudyPage() {
       
       if (cardIdParam) {
         // Estudiar una ficha específica
-        const response = await fetch(`/api/cards/${cardIdParam}`)
+        const response = await fetch(`/api/cards/${cardIdParam}`, {
+          credentials: 'include',
+        })
+        if (response.status === 401) {
+          window.location.href = '/login'
+          return
+        }
         if (response.ok) {
           const card = await response.json()
           setCards([card])
         }
       } else {
         // Estudiar todas las fichas
-        const response = await fetch('/api/cards?limit=50')
+        const response = await fetch('/api/cards?limit=50', {
+          credentials: 'include',
+        })
+        if (response.status === 401) {
+          window.location.href = '/login'
+          return
+        }
         if (response.ok) {
           const data = await response.json()
           setCards(data.cards)


### PR DESCRIPTION
## Summary
- include credentials in study page card fetches
- redirect unauthenticated users to `/login`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive config)*

------
https://chatgpt.com/codex/tasks/task_e_689f67b7cb2c8332b94a6b844d26da79