### PR TITLE
Handle unauthorized tag fetch

### DIFF
--- a/components/advanced-search.tsx
+++ b/components/advanced-search.tsx
@@ -76,7 +76,11 @@ export function AdvancedSearch({ onFiltersChange, totalResults, isLoading = fals
 
   const fetchTags = async () => {
     try {
-      const response = await fetch('/api/tags')
+      const response = await fetch('/api/tags', { credentials: 'include' })
+      if (response.status === 401) {
+        window.location.href = '/login'
+        return
+      }
       if (response.ok) {
         const tagsData = await response.json()
         setTags(tagsData)


### PR DESCRIPTION
## Summary
- include credentials when fetching tags
- redirect to login on unauthorized tag responses

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run type-check` *(fails: Argument of type 'Buffer<ArrayBufferLike>' is not assignable to parameter ...)*

------
https://chatgpt.com/codex/tasks/task_e_689f67a91a5883329b3100adae50d283