### PR TITLE
feat: expose login token for client storage

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -27,7 +27,12 @@ export async function POST(req: NextRequest) {
       process.env.AUTH_COOKIE_SECURE !== undefined
         ? process.env.AUTH_COOKIE_SECURE === 'true'
         : req.nextUrl.protocol === 'https:'
-    const res = NextResponse.json({ id: user.id, name: user.name, email: user.email })
+    const res = NextResponse.json({
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      token,
+    })
     res.cookies.set(AUTH_COOKIE, token, {
       httpOnly: true,
       secure,

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -53,10 +53,11 @@ export function useAuth() {
     if (!res.ok) {
       throw new Error('Login failed')
     }
-    const data = (await res.json()) as User
-    setUser(data)
-    localStorage.setItem('user', JSON.stringify(data))
-    return data
+    const { token, ...userData } = (await res.json()) as User & { token: string }
+    setUser(userData)
+    localStorage.setItem('user', JSON.stringify(userData))
+    localStorage.setItem('token', token)
+    return userData
   }, [])
 
   const logout = useCallback(() => {


### PR DESCRIPTION
## Summary
- include JWT token in login response
- store auth token in `useAuth` hook

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompts for ESLint configuration)
- `npm run type-check` (fails: TS errors in unrelated files)


------
https://chatgpt.com/codex/tasks/task_e_689f6cd2abc883329a21e4e4bce35be4