### PR TITLE
feat: add logout route and hook update

### DIFF
--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { AUTH_COOKIE } from '@/lib/auth'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(req: NextRequest) {
+  try {
+    const secure =
+      process.env.AUTH_COOKIE_SECURE !== undefined
+        ? process.env.AUTH_COOKIE_SECURE === 'true'
+        : req.nextUrl.protocol === 'https:'
+    const res = NextResponse.json({ success: true })
+    res.cookies.set(AUTH_COOKIE, '', {
+      httpOnly: true,
+      secure,
+      sameSite: 'lax',
+      path: '/',
+      maxAge: 0,
+    })
+    return res
+  } catch (error) {
+    console.error('Error in logout:', error)
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 })
+  }
+}

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -1,7 +1,6 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
-import { AUTH_COOKIE } from '@/lib/auth'
 
 interface User {
   id: string
@@ -59,9 +58,11 @@ export function useAuth() {
     return data
   }, [])
 
-  const logout = useCallback(() => {
-    if (typeof document !== 'undefined') {
-      document.cookie = `${AUTH_COOKIE}=; Max-Age=0; path=/`
+  const logout = useCallback(async () => {
+    try {
+      await fetch('/api/auth/logout', { method: 'POST', credentials: 'include' })
+    } catch {
+      // ignore errors
     }
     localStorage.removeItem('user')
     localStorage.removeItem('Authorization')


### PR DESCRIPTION
## Summary
- add `/api/auth/logout` route clearing auth cookie
- update `useAuth.logout` to call API instead of manipulating cookies

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_689f6cd520ac8332b506f4542492a79f