### PR TITLE
feat: centralize authenticated fetch logic

### DIFF
--- a/components/advanced-search.tsx
+++ b/components/advanced-search.tsx
@@ -24,6 +24,7 @@ import {
 } from 'lucide-react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { debounce } from 'lodash'
+import { authFetch } from '@/lib/authFetch'
 
 interface Tag {
   id: string
@@ -76,7 +77,7 @@ export function AdvancedSearch({ onFiltersChange, totalResults, isLoading = fals
 
   const fetchTags = async () => {
     try {
-      const response = await fetch('/api/tags', { credentials: 'include' })
+      const response = await authFetch('/api/tags')
       if (response.status === 401) {
         window.location.href = '/login'
         return

--- a/components/enhanced-home-page.tsx
+++ b/components/enhanced-home-page.tsx
@@ -13,6 +13,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Brain, Plus, BookOpen, Target, Zap, Users, Settings } from 'lucide-react'
 import Link from 'next/link'
 import { motion } from 'framer-motion'
+import { authFetch } from '@/lib/authFetch'
 
 interface CardData {
   id: string
@@ -83,9 +84,7 @@ export function EnhancedHomePage() {
       }
       if (filters.dateRange !== 'all') params.set('dateRange', filters.dateRange)
 
-      const response = await fetch(`/api/cards/search?${params}`, {
-        credentials: 'include'
-      })
+      const response = await authFetch(`/api/cards/search?${params}`)
       if (response.status === 401) {
         setError('Debes iniciar sesión para ver tus fichas')
         setCards([])

--- a/components/home-page.tsx
+++ b/components/home-page.tsx
@@ -12,6 +12,7 @@ import { Brain, Plus, BookOpen, Target, Zap, Users } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { motion } from 'framer-motion'
+import { authFetch } from '@/lib/authFetch'
 
 interface CardData {
   id: string
@@ -64,9 +65,7 @@ export function HomePage() {
       if (searchQuery) params.set('search', searchQuery)
       if (selectedTag) params.set('tag', selectedTag)
 
-      const response = await fetch(`/api/cards?${params}`, {
-        credentials: 'include'
-      })
+      const response = await authFetch(`/api/cards?${params}`)
       if (response.status === 401) {
         router.push('/login')
         return

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { useAuth } from '@/hooks/useAuth'
+import { authFetch } from '@/lib/authFetch'
 import { 
   Brain, 
   Search, 
@@ -59,7 +60,7 @@ export function Navigation({ onSearch, onTagFilter, searchQuery = '', selectedTa
 
   const fetchTags = async () => {
     try {
-      const response = await fetch('/api/tags', { credentials: 'include' })
+      const response = await authFetch('/api/tags')
       if (response.status === 401) {
         logout()
         router.push('/login')

--- a/components/study-page.tsx
+++ b/components/study-page.tsx
@@ -12,6 +12,7 @@ import { Card, CardContent } from '@/components/ui/card'
 import { ArrowLeft, BookOpen, Shuffle, Target, Maximize, Monitor } from 'lucide-react'
 import { motion } from 'framer-motion'
 import Link from 'next/link'
+import { authFetch } from '@/lib/authFetch'
 
 interface CardData {
   id: string
@@ -46,9 +47,7 @@ export function StudyPage() {
       
       if (cardIdParam) {
         // Estudiar una ficha específica
-        const response = await fetch(`/api/cards/${cardIdParam}`, {
-          credentials: 'include',
-        })
+        const response = await authFetch(`/api/cards/${cardIdParam}`)
         if (response.status === 401) {
           window.location.href = '/login'
           return
@@ -59,9 +58,7 @@ export function StudyPage() {
         }
       } else {
         // Estudiar todas las fichas
-        const response = await fetch('/api/cards?limit=50', {
-          credentials: 'include',
-        })
+        const response = await authFetch('/api/cards?limit=50')
         if (response.status === 401) {
           window.location.href = '/login'
           return

--- a/lib/authFetch.ts
+++ b/lib/authFetch.ts
@@ -1,0 +1,18 @@
+export function authFetch(input: RequestInfo | URL, init: RequestInit = {}) {
+  const token =
+    typeof window !== 'undefined'
+      ? localStorage.getItem('token') || localStorage.getItem('Authorization')
+      : null
+
+  const headers = new Headers(init.headers || {})
+  if (token) {
+    headers.set('Authorization', token.startsWith('Bearer ') ? token : `Bearer ${token}`)
+  }
+
+  return fetch(input, {
+    ...init,
+    credentials: 'include',
+    headers,
+  })
+}
+


### PR DESCRIPTION
## Summary
- add `authFetch` helper that automatically attaches saved auth tokens and credentials
- refactor navigation and pages to use `authFetch` instead of raw `fetch`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run type-check` *(fails: Argument type mismatch in route.ts and missing types in theme-provider.tsx & calendar.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_689f6cd3b0348332bba5f6556d21218a